### PR TITLE
fix floating-text-format-toolbar-plugin dark

### DIFF
--- a/components/editor/plugins/floating-text-format-toolbar-plugin.tsx
+++ b/components/editor/plugins/floating-text-format-toolbar-plugin.tsx
@@ -202,7 +202,7 @@ function TextFormatFloatingToolbar({
   return (
     <div
       ref={popupCharStylesEditorRef}
-      className="absolute left-0 top-0 z-10 flex gap-1 rounded-md border bg-accent p-1 opacity-0 shadow-md transition-opacity duration-300 will-change-transform"
+      className="absolute left-0 top-0 z-10 flex gap-1 rounded-md border bg-card p-1 opacity-0 shadow-md transition-opacity duration-300 will-change-transform"
     >
       {editor.isEditable() && (
         <>

--- a/components/editor/plugins/floating-text-format-toolbar-plugin.tsx
+++ b/components/editor/plugins/floating-text-format-toolbar-plugin.tsx
@@ -202,7 +202,7 @@ function TextFormatFloatingToolbar({
   return (
     <div
       ref={popupCharStylesEditorRef}
-      className="absolute left-0 top-0 z-10 flex gap-1 rounded-md border bg-white p-1 opacity-0 shadow-md transition-opacity duration-300 will-change-transform"
+      className="absolute left-0 top-0 z-10 flex gap-1 rounded-md border bg-transparent p-1 opacity-0 shadow-md transition-opacity duration-300 will-change-transform"
     >
       {editor.isEditable() && (
         <>

--- a/components/editor/plugins/floating-text-format-toolbar-plugin.tsx
+++ b/components/editor/plugins/floating-text-format-toolbar-plugin.tsx
@@ -202,7 +202,7 @@ function TextFormatFloatingToolbar({
   return (
     <div
       ref={popupCharStylesEditorRef}
-      className="absolute left-0 top-0 z-10 flex gap-1 rounded-md border bg-transparent p-1 opacity-0 shadow-md transition-opacity duration-300 will-change-transform"
+      className="absolute left-0 top-0 z-10 flex gap-1 rounded-md border bg-accent p-1 opacity-0 shadow-md transition-opacity duration-300 will-change-transform"
     >
       {editor.isEditable() && (
         <>


### PR DESCRIPTION
uses `bg-accent`

<img width="478" alt="image" src="https://github.com/user-attachments/assets/d7b402bd-d2ca-4bb6-919a-a0205e7fa7df" />
