### PR TITLE
collapsible-container toggle icon

### DIFF
--- a/components/editor/nodes/collapsible-container-node.ts
+++ b/components/editor/nodes/collapsible-container-node.ts
@@ -73,7 +73,7 @@ export class CollapsibleContainerNode extends ElementNode {
       })
       dom = detailsDom
     }
-    dom.classList.add('bg-background', 'border', 'rounded-lg', 'mb-2')
+    dom.classList.add('Collapsible__container')
 
     return dom
   }
@@ -126,7 +126,7 @@ export class CollapsibleContainerNode extends ElementNode {
 
   exportDOM(): DOMExportOutput {
     const element = document.createElement('details')
-    element.classList.add('bg-background', 'border', 'rounded-lg', 'mb-2')
+    element.classList.add('Collapsible__container')
     element.setAttribute('open', this.__open.toString())
     return { element }
   }

--- a/components/editor/nodes/collapsible-title-node.ts
+++ b/components/editor/nodes/collapsible-title-node.ts
@@ -45,15 +45,7 @@ export class CollapsibleTitleNode extends ElementNode {
 
   createDOM(config: EditorConfig, editor: LexicalEditor): HTMLElement {
     const dom = document.createElement('summary')
-    dom.classList.add(
-      'p-1',
-      'pl-4',
-      'relative',
-      'font-bold',
-      'list-none',
-      'outline-none',
-      'cursor-pointer'
-    )
+    dom.classList.add('Collapsible__title')
     if (IS_CHROME) {
       dom.addEventListener('click', () => {
         editor.update(() => {

--- a/components/editor/plugins/code-action-menu-plugin.tsx
+++ b/components/editor/plugins/code-action-menu-plugin.tsx
@@ -140,7 +140,7 @@ function CodeActionMenuContainer({
     <>
       {isShown ? (
         <div
-          className="code-action-menu-container user-select-none absolute flex h-9 flex-row items-center space-x-1 text-xs text-black/50"
+          className="code-action-menu-container user-select-none absolute flex h-9 flex-row items-center space-x-1 text-xs text-foreground/50"
           style={{ ...position }}
         >
           <div>{codeFriendlyName}</div>

--- a/components/editor/plugins/floating-text-format-toolbar-plugin.tsx
+++ b/components/editor/plugins/floating-text-format-toolbar-plugin.tsx
@@ -202,7 +202,7 @@ function TextFormatFloatingToolbar({
   return (
     <div
       ref={popupCharStylesEditorRef}
-      className="absolute left-0 top-0 z-10 flex gap-1 rounded-md border p-1 opacity-0 shadow-md transition-opacity duration-300 will-change-transform"
+      className="absolute left-0 top-0 z-10 flex gap-1 rounded-md border p-1 opacity-0 shadow-md transition-opacity duration-300 will-change-transform bg-background"
     >
       {editor.isEditable() && (
         <>

--- a/components/editor/plugins/toolbar/toolbar-plugin.tsx
+++ b/components/editor/plugins/toolbar/toolbar-plugin.tsx
@@ -17,6 +17,7 @@ import { FormatNumberedList } from './block-format/format-numbered-list'
 import { FormatParagraph } from './block-format/format-paragraph'
 import { FormatQuote } from './block-format/format-quote'
 import { BlockInsertPlugin } from './block-insert-plugin'
+import { InsertCollapsibleContainer } from './block-insert/insert-collapsible-container'
 import { InsertColumnsLayout } from './block-insert/insert-columns-layout'
 import { InsertEmbeds } from './block-insert/insert-embeds'
 import { InsertExcalidraw } from './block-insert/insert-excalidraw'
@@ -107,6 +108,7 @@ export function ToolbarPlugin() {
               <InsertPageBreak />
               <InsertImage />
               <InsertInlineImage />
+              <InsertCollapsibleContainer/>
               <InsertExcalidraw />
               <InsertTable />
               <InsertPoll />

--- a/components/editor/themes/editor-theme.css
+++ b/components/editor/themes/editor-theme.css
@@ -61,3 +61,31 @@
 .EditorTheme__tokenFunction {
   color: #dd4a68;
 }
+
+.Collapsible__container {
+  background-color: var(--background);
+  border: 1px solid #ccc;
+  border-radius: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.Collapsible__title{
+  padding: 0.25rem;
+  padding-left: 1rem;
+  position: relative;
+  font-weight: bold;
+  outline: none;
+  cursor: pointer;
+  list-style-type: disclosure-closed;
+  list-style-position: inside;
+}
+
+.Collapsible__title p{
+  display: inline-flex;
+}
+.Collapsible__title::marker{
+  color: lightgray;
+}
+.Collapsible__container[open] >.Collapsible__title {
+  list-style-type: disclosure-open;
+}

--- a/components/editor/themes/editor-theme.css
+++ b/components/editor/themes/editor-theme.css
@@ -1,5 +1,5 @@
 .EditorTheme__code {
-  background-color: rgba(255, 255, 255, 0.9);
+  background-color: transparent;
   font-family: Menlo, Consolas, Monaco, monospace;
   display: block;
   padding: 8px 8px 8px 52px;
@@ -17,7 +17,7 @@
 .EditorTheme__code:before {
   content: attr(data-gutter);
   position: absolute;
-  background-color: rgba(255, 255, 255, 0.9);
+  background-color: transparent;
   border-right: 1px solid #ccc;
   left: 0;
   top: 0;

--- a/components/editor/ui/code-button.tsx
+++ b/components/editor/ui/code-button.tsx
@@ -62,7 +62,7 @@ export function CopyButton({ editor, getCodeDOMNode }: Props) {
 
   return (
     <button
-      className="flex shrink-0 cursor-pointer items-center rounded border border-transparent bg-none p-1 uppercase text-black/50"
+      className="flex shrink-0 cursor-pointer items-center rounded border border-transparent bg-none p-1 uppercase text-foreground/50"
       onClick={handleClick}
       aria-label="copy"
     >


### PR DESCRIPTION
1. feat : collapsible-container toggle icon inside

I think you deliberately did 'list-none' because you wanted a clean UI. 
I tried adding a collapsible-container toggle icon.

![Jan-17-2025 03-33-17](https://github.com/user-attachments/assets/be3f7ef0-4f5b-4f3d-b585-2fbcc78ba9b5)

2. fix : dark theme
<img width="1466" alt="스크린샷 2025-01-17 오전 4 04 09" src="https://github.com/user-attachments/assets/a0dfc25e-34db-400c-9082-54bc149b7bc0" />


3. fix : floating toolbar background
<img width="470" alt="스크린샷 2025-01-17 오전 4 04 21" src="https://github.com/user-attachments/assets/d55bb340-1b90-4922-afa8-12edfffcd839" />
