### PR TITLE
fix : Tooltip Dialog conflict issue

### DIFF
--- a/components/editor/plugins/actions/clear-editor-plugin.tsx
+++ b/components/editor/plugins/actions/clear-editor-plugin.tsx
@@ -13,51 +13,48 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 
 export function ClearEditorActionPlugin() {
   const [editor] = useLexicalComposerContext()
+
   return (
-    <>
-      <Dialog>
-        <DialogTrigger asChild>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button size={'sm'} variant={'ghost'} className="p-2">
-                <Trash2Icon className="h-4 w-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Clear Editor</TooltipContent>
-          </Tooltip>
-        </DialogTrigger>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Clear Editor</DialogTitle>
-          </DialogHeader>
+    <Dialog>
+      <Tooltip disableHoverableContent>
+        <TooltipTrigger asChild>
+          <DialogTrigger asChild>
+            <Button size={'sm'} variant={'ghost'} className="p-2">
+              <Trash2Icon className="h-4 w-4" />
+            </Button>
+          </DialogTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Clear Editor</TooltipContent>
+      </Tooltip>
+
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Clear Editor</DialogTitle>
           <DialogDescription>
             Are you sure you want to clear the editor?
           </DialogDescription>
-          <DialogFooter>
-            <DialogClose asChild>
-              <Button variant="outline">Cancel</Button>
-            </DialogClose>
-            <DialogClose asChild>
-              <Button
-                variant="destructive"
-                onClick={() => {
-                  editor.dispatchCommand(CLEAR_EDITOR_COMMAND, undefined)
-                }}
-              >
-                Clear
-              </Button>
-            </DialogClose>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </>
+        </DialogHeader>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline">Cancel</Button>
+          </DialogClose>
+
+          <DialogClose asChild>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                editor.dispatchCommand(CLEAR_EDITOR_COMMAND, undefined)
+              }}
+            >
+              Clear
+            </Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   )
 }


### PR DESCRIPTION
This PR resolves a focus conflict issue when using `@radix-ui/react-tooltip` and `@radix-ui/react-dialog` together.
Previously, when a button was used for both `TooltipTrigger` and `DialogTrigger`, the Dialog would not open properly due to focus management conflicts.


**To fix this:**
- The `DialogContent` and `TooltipContent` have been separated into distinct components.
- The `Tooltip` and `Dialog components` were reorganized so that the `DialogContent` renders outside the `Tooltip` hierarchy.