### PR TITLE
fix: Removed toast from share-content-plugin.json

### DIFF
--- a/__registry__/index.tsx
+++ b/__registry__/index.tsx
@@ -349,7 +349,7 @@ export const Index: Record<string, any> = {
       name: "share-content-plugin",
       description: "",
       type: "registry:ui",
-      registryDependencies: ["button","tooltip","sonner","toast","https://shadcn-editor.vercel.app/r/actions-plugin.json"],
+      registryDependencies: ["button","tooltip","sonner","https://shadcn-editor.vercel.app/r/actions-plugin.json"],
       files: [{
         path: "registry/new-york/editor/plugins/actions/share-content-plugin.tsx",
         type: "registry:component",
@@ -2945,7 +2945,7 @@ export const Index: Record<string, any> = {
       name: "share-content-plugin",
       description: "",
       type: "registry:ui",
-      registryDependencies: ["button","tooltip","sonner","toast","https://shadcn-editor.vercel.app/r/actions-plugin.json"],
+      registryDependencies: ["button","tooltip","sonner","https://shadcn-editor.vercel.app/r/actions-plugin.json"],
       files: [{
         path: "registry/default/editor/plugins/actions/share-content-plugin.tsx",
         type: "registry:component",

--- a/public/r/share-content-plugin.json
+++ b/public/r/share-content-plugin.json
@@ -11,7 +11,6 @@
     "button",
     "tooltip",
     "sonner",
-    "toast",
     "https://shadcn-editor.vercel.app/r/actions-plugin.json"
   ],
   "files": [

--- a/registry/registry-ui.ts
+++ b/registry/registry-ui.ts
@@ -393,7 +393,6 @@ export const ui: Registry["items"] = [
       "button",
       "tooltip",
       "sonner",
-      "toast",
       "https://shadcn-editor.vercel.app/r/actions-plugin.json",
     ],
     "files": [


### PR DESCRIPTION
Fixes #45 

- Removed `toast` from `registryDependancies` as it is deprecated in `shadcn/ui`, which was causing an error during installation.