### PR TITLE
Style the font family dropdown text (e.g. 'Times New Roman', 'Arial',…

### DIFF
--- a/registry/new-york-v4/editor/plugins/toolbar/font-family-toolbar-plugin.tsx
+++ b/registry/new-york-v4/editor/plugins/toolbar/font-family-toolbar-plugin.tsx
@@ -69,11 +69,15 @@ export function FontFamilyToolbarPlugin() {
     >
       <SelectTrigger className="!h-8 w-min gap-1">
         <TypeIcon className="size-4" />
-        <span>{fontFamily}</span>
+        <span style={{ fontFamily }}>{fontFamily}</span>
       </SelectTrigger>
       <SelectContent>
         {FONT_FAMILY_OPTIONS.map((option) => (
-          <SelectItem key={option} value={option}>
+          <SelectItem
+            key={option}
+            value={option}
+            style={{ fontFamily: option }}
+          >
             {option}
           </SelectItem>
         ))}


### PR DESCRIPTION
… 'Courier New', ...) according to the actual font-family instead of them being all Arial

Not sure if this is intentional, here's the before and after of this code change.

### before
<img width="408" height="314" alt="Screenshot 2025-07-20 at 3 21 48 PM" src="https://github.com/user-attachments/assets/f0d119e4-17da-4986-b998-2d57ca55dd23" />


### after
<img width="616" height="290" alt="Screenshot 2025-07-20 at 3 21 18 PM" src="https://github.com/user-attachments/assets/3e6df598-e596-489d-b247-ad460791335e" />
