### PR TITLE
Fix for typo in format-bulleted-list.tsx component.

### DIFF
--- a/registry/new-york-v4/editor/plugins/toolbar/block-format/format-bulleted-list.tsx
+++ b/registry/new-york-v4/editor/plugins/toolbar/block-format/format-bulleted-list.tsx
@@ -21,7 +21,7 @@ export function FormatBulletedList() {
   }
 
   const formatBulletedList = () => {
-    if (blockType !== "number") {
+    if (blockType !== "bullet") {
       activeEditor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND, undefined)
     } else {
       formatParagraph()


### PR DESCRIPTION
Fix for #64 

Note: I'm the same guy that created the issue, this is just my personal GitHub account.