### PR TITLE
Refactor Tailwind CSS utilities and button size

### DIFF
--- a/registry/new-york-v4/editor/plugins/toolbar/clear-formatting-toolbar-plugin.tsx
+++ b/registry/new-york-v4/editor/plugins/toolbar/clear-formatting-toolbar-plugin.tsx
@@ -77,13 +77,13 @@ export function ClearFormattingToolbarPlugin() {
 
   return (
     <Button
-      className="!h-8 !w-8"
+      className="!size-8"
       aria-label="Clear formatting"
       variant={"outline"}
-      size={"icon"}
+      size={"icon-sm"}
       onClick={clearFormatting}
     >
-      <EraserIcon className="h-4 w-4" />
+      <EraserIcon className="size-4" />
     </Button>
   )
 }

--- a/registry/new-york-v4/editor/plugins/toolbar/font-background-toolbar-plugin.tsx
+++ b/registry/new-york-v4/editor/plugins/toolbar/font-background-toolbar-plugin.tsx
@@ -85,7 +85,7 @@ export function FontBackgroundToolbarPlugin() {
     >
       <ColorPickerTrigger asChild>
         <Button variant={"outline"} size={"icon-sm"}>
-          <PaintBucketIcon className="h-4 w-4" />
+          <PaintBucketIcon className="size-4" />
         </Button>
       </ColorPickerTrigger>
       <ColorPickerContent>

--- a/registry/new-york-v4/editor/plugins/toolbar/font-color-toolbar-plugin.tsx
+++ b/registry/new-york-v4/editor/plugins/toolbar/font-color-toolbar-plugin.tsx
@@ -73,7 +73,7 @@ export function FontColorToolbarPlugin() {
     >
       <ColorPickerTrigger asChild>
         <Button variant="outline" size="icon-sm">
-          <BaselineIcon className="h-4 w-4" />
+          <BaselineIcon className="size-4" />
         </Button>
       </ColorPickerTrigger>
       <ColorPickerContent>

--- a/registry/new-york-v4/editor/plugins/toolbar/font-format-toolbar-plugin.tsx
+++ b/registry/new-york-v4/editor/plugins/toolbar/font-format-toolbar-plugin.tsx
@@ -76,7 +76,7 @@ export function FontFormatToolbarPlugin() {
             )
           }}
         >
-          <Icon className="h-4 w-4" />
+          <Icon className="size-4" />
         </ToggleGroupItem>
       ))}
     </ToggleGroup>

--- a/registry/new-york-v4/editor/plugins/toolbar/font-size-toolbar-plugin.tsx
+++ b/registry/new-york-v4/editor/plugins/toolbar/font-size-toolbar-plugin.tsx
@@ -57,8 +57,8 @@ export function FontSizeToolbarPlugin() {
     <ButtonGroup>
       <Button
         variant="outline"
-        size="icon"
-        className="!h-8 !w-8"
+        size="icon-sm"
+        className="!size-8"
         onClick={() => updateFontSize(fontSize - 1)}
         disabled={fontSize <= MIN_FONT_SIZE}
       >
@@ -75,8 +75,8 @@ export function FontSizeToolbarPlugin() {
       />
       <Button
         variant="outline"
-        size="icon"
-        className="!h-8 !w-8"
+        size="icon-sm"
+        className="!size-8"
         onClick={() => updateFontSize(fontSize + 1)}
         disabled={fontSize >= MAX_FONT_SIZE}
       >

--- a/registry/new-york-v4/editor/plugins/toolbar/link-toolbar-plugin.tsx
+++ b/registry/new-york-v4/editor/plugins/toolbar/link-toolbar-plugin.tsx
@@ -77,7 +77,7 @@ export function LinkToolbarPlugin({
     <Toggle
       variant={"outline"}
       size="sm"
-      className="!h-8 !w-8"
+      className="!size-8"
       aria-label="Toggle link"
       onClick={insertLink}
     >

--- a/registry/new-york-v4/editor/plugins/toolbar/subsuper-toolbar-plugin.tsx
+++ b/registry/new-york-v4/editor/plugins/toolbar/subsuper-toolbar-plugin.tsx
@@ -44,7 +44,7 @@ export function SubSuperToolbarPlugin() {
         }}
         variant={"outline"}
       >
-        <SubscriptIcon className="h-4 w-4" />
+        <SubscriptIcon className="size-4" />
       </ToggleGroupItem>
       <ToggleGroupItem
         value="superscript"
@@ -55,7 +55,7 @@ export function SubSuperToolbarPlugin() {
         }}
         variant={"outline"}
       >
-        <SuperscriptIcon className="h-4 w-4" />
+        <SuperscriptIcon className="size-4" />
       </ToggleGroupItem>
     </ToggleGroup>
   )


### PR DESCRIPTION
## Changes:
- replaced  `h` and `w`  Tailwind Css utilities with `size`.
- replaced button `size="icon"` with `size="icon-sm"` in `font-size-toolbar-plugin.tsx` and `clear-formatting-toolbar-plugin.tsx`

## Files Modified

`clear-formatting-toolbar-plugin.tsx`
`font-background-toolbar-plugin.tsx`
`font-color-toolbar-plugin.tsx`
`font-format-toolbar-plugin.tsx`
`font-size-toolbar-plugin.tsx`
`link-toolbar-plugin.tsx`
`subsuper-toolbar-plugin.tsx`