### PR TITLE
fix #82: define missing h4, h5, h6 icons and apply them in the demo

### DIFF
--- a/registry/new-york-v4/blocks/editor-x/plugins.tsx
+++ b/registry/new-york-v4/blocks/editor-x/plugins.tsx
@@ -127,7 +127,7 @@ export function Plugins({}) {
             <Separator orientation="vertical" className="!h-7" />
             <BlockFormatDropDown>
               <FormatParagraph />
-              <FormatHeading levels={["h1", "h2", "h3"]} />
+              <FormatHeading levels={["h1", "h2", "h3", "h4", "h5", "h6"]} />
               <FormatNumberedList />
               <FormatBulletedList />
               <FormatCheckList />

--- a/registry/new-york-v4/editor/plugins/toolbar/block-format/block-format-data.tsx
+++ b/registry/new-york-v4/editor/plugins/toolbar/block-format/block-format-data.tsx
@@ -3,6 +3,9 @@ import {
   Heading1Icon,
   Heading2Icon,
   Heading3Icon,
+  Heading4Icon,
+  Heading5Icon,
+  Heading6Icon,
   ListIcon,
   ListOrderedIcon,
   ListTodoIcon,
@@ -29,6 +32,18 @@ export const blockTypeToBlockName: Record<
   h3: {
     label: "Heading 3",
     icon: <Heading3Icon className="size-4" />,
+  },
+  h4: {
+    label: "Heading 4",
+    icon: <Heading4Icon className="size-4" />,
+  },
+  h5: {
+    label: "Heading 5",
+    icon: <Heading5Icon className="size-4" />,
+  },
+  h6: {
+    label: "Heading 6",
+    icon: <Heading6Icon className="size-4" />,
   },
   number: {
     label: "Numbered List",


### PR DESCRIPTION
fix for #82

## Changes
I created the missed icons and applied them to the demo, as showing in the image below.

<img width="653" height="318" alt="image" src="https://github.com/user-attachments/assets/6d780379-687f-42d4-9d57-a993c746e24d" />

## Files Modified
`plugins.tsx`
`block-format-data.tsx`

