### PR TITLE
fix #79: stick picker menu to '/' command, even if scrolling

### DIFF
--- a/registry/new-york-v4/editor/plugins/component-picker-menu-plugin.tsx
+++ b/registry/new-york-v4/editor/plugins/component-picker-menu-plugin.tsx
@@ -55,7 +55,7 @@ function ComponentPickerMenu({
   }, [selectedIndex])
 
   return (
-    <div className="fixed z-10 w-[250px] h-min rounded-md shadow-md">
+    <div className="absolute z-10 w-[250px] h-min rounded-md shadow-md">
       <Command
         onKeyDown={(e) => {
           if (e.key === "ArrowUp") {


### PR DESCRIPTION
fix #79 

## Changes
stick command list to editor command `/` from top and bottom, depends on the viewport.

BEFORE:

https://github.com/user-attachments/assets/7c51d3e4-e09a-42ff-bad7-b87c791be5fd

AFTER:

https://github.com/user-attachments/assets/edfa546e-c47a-4275-964c-d2ebda56b886

## File Modified
- `component-picker-menu-plugin.tsx`