### PR TITLE
fix #49: create underlineStrikethrough properly

### DIFF
--- a/registry/new-york-v4/editor/themes/editor-theme.ts
+++ b/registry/new-york-v4/editor/themes/editor-theme.ts
@@ -52,7 +52,7 @@ export const editorTheme: EditorThemeClasses = {
     subscript: "sub",
     superscript: "sup",
     underline: "underline",
-    underlineStrikethrough: "underline line-through",
+    underlineStrikethrough: "[text-decoration:underline_line-through]",
   },
   image: "relative inline-block user-select-none cursor-default editor-image",
   inlineImage:


### PR DESCRIPTION
fix #49

## Changes
tailwind css accepts only single utility for `text-decuration`, thus, we must use custom util or css class.

BEFORE:
<img width="605" height="186" alt="image" src="https://github.com/user-attachments/assets/80443119-3e2f-430a-9dae-bd3de974bf6d" />


AFTER:
<img width="739" height="179" alt="image" src="https://github.com/user-attachments/assets/a5cba561-59f4-4a7f-b09c-69d084c2fd74" />

## File Modified
`editor-theme.ts`